### PR TITLE
strip version restrictions for SubLibraries as well

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -25,6 +25,9 @@ main = getArgs >>= mapM_ (\cabalFile -> readGenericPackageDescription silent cab
 -- See https://github.com/peti/jailbreak-cabal/commit/99eac40deb481b185fd93fd307625369ff5e1ec0
 stripVersionRestrictions :: GenericPackageDescription -> GenericPackageDescription
 stripVersionRestrictions pkg = pkg { condLibrary = fmap relaxLibraryTree (condLibrary pkg)
+#if MIN_VERSION_Cabal(2,0,0)
+                                   , condSubLibraries = map (\(n, l) -> (n, relaxLibraryTree l)) (condSubLibraries pkg)
+#endif
                                    , condExecutables = map (fmap relaxExeTree) (condExecutables pkg)
                                    , condTestSuites = map (fmap relaxTestTree) (condTestSuites pkg)
                                    }


### PR DESCRIPTION
Since Cabal 2.x packages can have internal sub-libraries,

https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs

One example of such a package is haskell-ci. If you run `jailbreak-cabal` on `haskell-ci.cabal` it lifts version restrictions for things like the test suite, but not the version restrictions for the internal library.

This patch updates `jailbreak-cabal` so that it also lifts the version restrictions for dependencies of sub-libraries.